### PR TITLE
flussab-cnf: Treat % as EOF

### DIFF
--- a/flussab-cnf/src/cnf.rs
+++ b/flussab-cnf/src/cnf.rs
@@ -580,4 +580,13 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn percent_eof() -> Result<()> {
+        let mut parser = Parser::<i32>::from_read("p cnf 2 1\n-1 2 0\n%\n0\n".as_bytes(), true)?;
+
+        assert_eq!(parser.next_clause()?, Some(&[-1, 2][..]));
+        assert_eq!(parser.next_clause()?, None);
+        Ok(())
+    }
 }

--- a/flussab-cnf/src/token.rs
+++ b/flussab-cnf/src/token.rs
@@ -147,6 +147,10 @@ pub fn interactive_newline(input: &mut LineReader) -> Parsed<(), ParseError> {
 
 #[inline]
 pub fn eof(input: &mut LineReader) -> Parsed<(), ParseError> {
+    if let Some(b'%') = input.reader.request_byte() {
+        return Res(Ok(()));
+    }
+
     if input.reader.request_byte().is_none() && input.reader.io_error().is_none() {
         Res(Ok(()))
     } else {


### PR DESCRIPTION
The SATLIB benchmarks (available [here][1]) make use of a slightly non-standard CNF format, where % is placed after the data proper, after which some metadata follows (which is just the number "0" in the instances I've looked at). Following [SAT4J's parser][2], this PR makes `flussab-cnf` treat that as EOF.

[1]: https://www.cs.ubc.ca/~hoos/SATLIB/benchm.html
[2]: https://gitlab.ow2.org/sat4j/sat4j/-/blob/34cbcb248f2b2e6127fc34dcf028b848416bf45d/org.sat4j.core/src/main/java/org/sat4j/reader/DimacsReader.java#L177