### PR TITLE
aiger-flussab: Fix missing space when writing ascii latch init

### DIFF
--- a/flussab-aiger/src/ascii.rs
+++ b/flussab-aiger/src/ascii.rs
@@ -875,6 +875,7 @@ where
             Some(true) => self.writer.write_all_defer_err(b" 1\n"),
             Some(false) => self.writer.write_all_defer_err(b"\n"),
             None => {
+                self.writer.write_all_defer_err(b" ");
                 flussab::write::text::ascii_digits(&mut self.writer, latch.state.code());
                 self.writer.write_all_defer_err(b"\n");
             }


### PR DESCRIPTION
This fixes #3